### PR TITLE
Add IP Access Handler to Solr's jetty configuration

### DIFF
--- a/java/etc/jetty.xml
+++ b/java/etc/jetty.xml
@@ -105,7 +105,47 @@
         <Set name="handlers">
          <Array type="org.eclipse.jetty.server.Handler">
            <Item>
-             <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection"/>
+            <!--
+              The IP Access Handler (wrapping ContextHandlerCollection)
+
+              By default an empty white list is treated as match all. If there is at least one entry in the white list, then a request must match a white list entry.
+              Black list entries are always applied, so that even if an entry matches the white list, a black list entry will override it. 
+
+              Examples of the entry specifications are:
+
+              10.10.1.2 - all requests from IP 10.10.1.2
+              10.10.1.2|/foo/bar - all requests from IP 10.10.1.2 to URI /foo/bar
+              10.10.1.2|/foo/* - all requests from IP 10.10.1.2 to URIs starting with /foo/
+              10.10.1.2|*.html - all requests from IP 10.10.1.2 to URIs ending with .html
+              10.10.0-255.0-255 - all requests from IPs within 10.10.0.0/16 subnet
+              10.10.0-.-255|/foo/bar - all requests from IPs within 10.10.0.0/16 subnet to URI /foo/bar
+              10.10.0-3,1,3,7,15|/foo/* - all requests from IPs addresses with last octet equal to 1,3,7,15 in subnet 10.10.0.0/22 to URIs starting with /foo/
+
+              source: http://download.eclipse.org/jetty/stable-9/apidocs/org/eclipse/jetty/server/handler/IPAccessHandler.html
+            -->
+            <New class="org.eclipse.jetty.server.handler.IPAccessHandler">
+              <Call name="setWhite">
+                <Arg>
+                  <Array type="String">
+                    <Item>127.0.0.1</Item>
+                    <!-- <Item>192.168.33.1</Item> -->
+                  </Array>
+                </Arg>
+              </Call>
+              <!--
+              <Call name="setBlack">
+                <Arg>
+                  <Array type="String">
+                    <Item>xxx.xxx.xxx.xxx</Item>
+                    <Item>xxx.xxx.xxx.xxx</Item>
+                  </Array>
+                </Arg>
+              </Call>
+              -->
+              <Set name="handler">
+                <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection"/>
+              </Set>
+            </New>
            </Item>
            <Item>
              <New id="DefaultHandler" class="org.eclipse.jetty.server.handler.DefaultHandler"/>


### PR DESCRIPTION
- updating the existing jetty configuration by wrapping the
ContextHandlerCollection handler with the IPAccessHandler
allows white/black lists to be configured to grant/deny access to
specified IPs.