### PR TITLE
Calling parent constructor correctly

### DIFF
--- a/classes/ezfindresultnode.php
+++ b/classes/ezfindresultnode.php
@@ -12,7 +12,7 @@ class eZFindResultNode extends eZContentObjectTreeNode
     */
     function eZFindResultNode( $rows = array() )
     {
-        $this->eZContentObjectTreeNode( $rows );
+        parent::__construct( $rows );
         if ( isset( $rows['id'] ) )
         {
             $this->ContentObjectID = $rows['id'];


### PR DESCRIPTION
It's a follow up of
https://github.com/ezsystems/ezfind/pull/211

Currently ezfind will through a fatal error search for an object.

*Testing instructions*
- in the admin interface do a search that will return result entries
- without this patch it will result in a PHP fatal error
- with this patch it will just show the result objects and there is no PHP fatal error