### PR TITLE
Removing old constructor syntax - removing closing php tag

### DIFF
--- a/classes/archive/filestorage/ezpfilearchive.php
+++ b/classes/archive/filestorage/ezpfilearchive.php
@@ -29,6 +29,3 @@ abstract class ezpFileArchive
 
 }
 
-
-
-?>

--- a/classes/archive/filestorage/ezpfilearchivefactory.php
+++ b/classes/archive/filestorage/ezpfilearchivefactory.php
@@ -34,5 +34,3 @@ class ezpFileArchiveFactory
 
 }
 
-
-?>

--- a/classes/archive/filestorage/ezpfilearchivefilesystem.php
+++ b/classes/archive/filestorage/ezpfilearchivefilesystem.php
@@ -76,5 +76,3 @@ class ezpFileArchiveFileSystem extends ezpFileArchive
     }
 
 }
-
-?>

--- a/classes/exceptions/ezfexception.php
+++ b/classes/exceptions/ezfexception.php
@@ -16,4 +16,4 @@ abstract class ezfBaseException extends ezcBaseException
 {
 
 }
-?>
+

--- a/classes/exceptions/ezfsolrexception.php
+++ b/classes/exceptions/ezfsolrexception.php
@@ -27,4 +27,4 @@ class ezfSolrException extends ezfBaseException
         parent::__construct( $message );
     }
 }
-?>
+

--- a/classes/ezdatatypesolrstorage.php
+++ b/classes/ezdatatypesolrstorage.php
@@ -31,4 +31,3 @@ class ezdatatypeSolrStorage
     }
 }
 
-?>

--- a/classes/ezfezpsolrquerybuilder.php
+++ b/classes/ezfezpsolrquerybuilder.php
@@ -14,7 +14,7 @@ class ezfeZPSolrQueryBuilder
      * @param Object $searchPluginInstance Search engine instance. Allows the query builder to
      *        communicate with the caller ( eZSolr instance ).
      */
-    function ezfeZPSolrQueryBuilder( $searchPluginInstance )
+    public function __construct( $searchPluginInstance )
     {
         $this->searchPluginInstance = $searchPluginInstance;
     }
@@ -1898,4 +1898,3 @@ class ezfeZPSolrQueryBuilder
     const FACET_MINCOUNT = 1;
 }
 
-?>

--- a/classes/ezfindresultnode.php
+++ b/classes/ezfindresultnode.php
@@ -10,7 +10,7 @@ class eZFindResultNode extends eZContentObjectTreeNode
     /*!
      \reimp
     */
-    function eZFindResultNode( $rows = array() )
+    public function __construct( $rows = array() )
     {
         parent::__construct( $rows );
         if ( isset( $rows['id'] ) )
@@ -131,4 +131,3 @@ class eZFindResultNode extends eZContentObjectTreeNode
     var $ResultObject;
 }
 
-?>

--- a/classes/ezfindresultobject.php
+++ b/classes/ezfindresultobject.php
@@ -10,7 +10,7 @@ class eZFindResultObject extends eZContentObject
     /*!
      \reimp
     */
-    function eZFindResultObject( $rows = array() )
+    function __construct( $rows = array() )
     {
         $this->LocalAttributeValueList = array();
         $this->LocalAttributeNameList = array( 'published' );
@@ -65,4 +65,3 @@ class eZFindResultObject extends eZContentObject
     var $LocalAttributeNameList;
 }
 
-?>

--- a/classes/ezfindservercallfunctions.php
+++ b/classes/ezfindservercallfunctions.php
@@ -204,4 +204,4 @@ class eZFindServerCallFunctions
 
     }
 }
-?>
+

--- a/classes/ezfmodulefunctioncollection.php
+++ b/classes/ezfmodulefunctioncollection.php
@@ -12,13 +12,6 @@
 class ezfModuleFunctionCollection
 {
     /**
-     * Constructor
-     */
-    function ezfModuleFunctionCollection()
-    {
-    }
-
-    /**
      * Get HTTP get facet parameters
      *
      * @return array HTTP GET facet parameters, as described in the facets
@@ -288,4 +281,4 @@ class ezfModuleFunctionCollection
         return array( 'result' => $facets );
     }
 }
-?>
+

--- a/classes/ezfsearchresultinfo.php
+++ b/classes/ezfsearchresultinfo.php
@@ -24,7 +24,7 @@ class ezfSearchResultInfo
      *           'Engine' => 'engine name',
      *           ... )
      */
-    function ezfSearchResultInfo( array $resultArray )
+    public function _construct( array $resultArray )
     {
         $this->ResultArray = $resultArray;
     }
@@ -366,4 +366,3 @@ class ezfSearchResultInfo
     protected $ResultArray;
 }
 
-?>

--- a/classes/ezfsolrdocumentfieldbase.php
+++ b/classes/ezfsolrdocumentfieldbase.php
@@ -555,4 +555,3 @@ class ezfSolrDocumentFieldBase
     const SUBATTR_FIELD_SEPARATOR = '___';
 }
 
-?>

--- a/classes/ezfsolrdocumentfielddummyexample.php
+++ b/classes/ezfsolrdocumentfielddummyexample.php
@@ -158,4 +158,4 @@ class ezfSolrDocumentFieldDummyExample extends ezfSolrDocumentFieldBase
         }
     }
 }
-?>
+

--- a/classes/ezfsolrdocumentfieldgmaplocation.php
+++ b/classes/ezfsolrdocumentfieldgmaplocation.php
@@ -107,4 +107,4 @@ class ezfSolrDocumentFieldGmapLocation extends ezfSolrDocumentFieldBase
         }
     }
 }
-?>
+

--- a/classes/ezfsolrdocumentfieldname.php
+++ b/classes/ezfsolrdocumentfieldname.php
@@ -13,13 +13,6 @@
 class ezfSolrDocumentFieldName
 {
     /**
-     *Constructor
-     */
-    function __construct()
-    {
-    }
-
-    /**
      * Lookup Solr schema field name. The lookup requires base name and
      * field type to generate the correct field name.
      *
@@ -143,4 +136,3 @@ class ezfSolrDocumentFieldName
     const LOOKUP_FILEDIR = 'ezfind';
 }
 
-?>

--- a/classes/ezfsolrdocumentfieldobjectrelation.php
+++ b/classes/ezfsolrdocumentfieldobjectrelation.php
@@ -357,4 +357,3 @@ class ezfSolrDocumentFieldObjectRelation extends ezfSolrDocumentFieldBase
     }
 }
 
-?>

--- a/classes/ezfsolrdocumentfieldxml.php
+++ b/classes/ezfsolrdocumentfieldxml.php
@@ -91,4 +91,3 @@ class ezfSolrDocumentFieldXML extends ezfSolrDocumentFieldBase
     }
 }
 
-?>

--- a/classes/ezfsolrstorage.php
+++ b/classes/ezfsolrstorage.php
@@ -29,11 +29,6 @@ class ezfSolrStorage
 
     /* var $handler; */
 
-    function  __construct( )
-    {
-
-    }
-
     /**
      * @param eZContentObjectAttribute $contentObjectAttribute the attribute to serialize
      * @return array for further processing
@@ -100,4 +95,3 @@ class ezfSolrStorage
     }
 }
 
-?>

--- a/classes/ezfsolrutils.php
+++ b/classes/ezfsolrutils.php
@@ -18,17 +18,6 @@ class ezfSolrUtils
 
     /**
      *
-     */
-
-
-    /*function  __construct( )
-    {
-
-    }*/
-
-
-    /**
-     *
      * @param eZSolrBase $fromCore
      * @param eZSolrBase $toCore
      * @param string $keyField
@@ -200,5 +189,3 @@ class ezfSolrUtils
 
 }
 
-
-?>

--- a/classes/ezsolrdoc.php
+++ b/classes/ezsolrdoc.php
@@ -156,5 +156,3 @@ class eZSolrDoc
 
 }
 
-
-?>

--- a/classes/indexplugins/ezfindexparentname.php
+++ b/classes/indexplugins/ezfindexparentname.php
@@ -45,4 +45,3 @@ class ezfIndexParentName implements ezfIndexPlugin
     }
 }
 
-?>

--- a/classes/indexplugins/ezfindexplugin.php
+++ b/classes/indexplugins/ezfindexplugin.php
@@ -24,4 +24,3 @@ interface ezfIndexPlugin
     public function modify( eZContentObject $contentObject, &$docList );
 }
 
-?>

--- a/classes/solrstorage/ezauthorsolrstorage.php
+++ b/classes/solrstorage/ezauthorsolrstorage.php
@@ -36,4 +36,3 @@ class ezauthorSolrStorage extends ezdatatypeSolrStorage
     }
 }
 
-?>

--- a/classes/solrstorage/ezbinaryfilesolrstorage.php
+++ b/classes/solrstorage/ezbinaryfilesolrstorage.php
@@ -59,5 +59,3 @@ class ezbinaryfileSolrStorage extends ezdatatypeSolrStorage
 
 }
 
-
-?>

--- a/classes/solrstorage/ezdatesolrstorage.php
+++ b/classes/solrstorage/ezdatesolrstorage.php
@@ -13,4 +13,3 @@ class ezdateSolrStorage extends ezdatetimeSolrStorage
 {
 }
 
-?>

--- a/classes/solrstorage/ezdatetimesolrstorage.php
+++ b/classes/solrstorage/ezdatetimesolrstorage.php
@@ -27,4 +27,3 @@ class ezdatetimeSolrStorage extends ezdatatypeSolrStorage
     }
 }
 
-?>

--- a/classes/solrstorage/ezenumsolrstorage.php
+++ b/classes/solrstorage/ezenumsolrstorage.php
@@ -36,4 +36,3 @@ class ezenumSolrStorage extends ezdatatypeSolrStorage
     }
 }
 
-?>

--- a/classes/solrstorage/ezkeywordsolrstorage.php
+++ b/classes/solrstorage/ezkeywordsolrstorage.php
@@ -26,4 +26,3 @@ class ezkeywordSolrStorage extends ezdatatypeSolrStorage
     }
 }
 
-?>

--- a/classes/solrstorage/ezmatrixsolrstorage.php
+++ b/classes/solrstorage/ezmatrixsolrstorage.php
@@ -36,5 +36,3 @@ class ezmatrixSolrStorage extends ezdatatypeSolrStorage
 
 }
 
-
-?>

--- a/classes/solrstorage/ezmultioptionsolrstorage.php
+++ b/classes/solrstorage/ezmultioptionsolrstorage.php
@@ -47,4 +47,3 @@ class ezmultioptionSolrStorage extends ezdatatypeSolrStorage
     }
 }
 
-?>

--- a/classes/solrstorage/ezobjectrelationlistsolrstorage.php
+++ b/classes/solrstorage/ezobjectrelationlistsolrstorage.php
@@ -33,4 +33,3 @@ class ezobjectrelationlistSolrStorage extends ezdatatypeSolrStorage
     }
 }
 
-?>

--- a/classes/solrstorage/ezoptionsolrstorage.php
+++ b/classes/solrstorage/ezoptionsolrstorage.php
@@ -41,4 +41,3 @@ class ezoptionSolrStorage extends ezdatatypeSolrStorage
     }
 }
 
-?>

--- a/classes/solrstorage/ezpricesolrstorage.php
+++ b/classes/solrstorage/ezpricesolrstorage.php
@@ -32,4 +32,3 @@ class ezpriceSolrStorage extends ezdatatypeSolrStorage
     }
 }
 
-?>

--- a/classes/solrstorage/ezproductcategorysolrstorage.php
+++ b/classes/solrstorage/ezproductcategorysolrstorage.php
@@ -31,4 +31,3 @@ class ezproductcategorySolrStorage extends ezdatatypeSolrStorage
     }
 }
 
-?>

--- a/classes/solrstorage/ezrangeoptionsolrstorage.php
+++ b/classes/solrstorage/ezrangeoptionsolrstorage.php
@@ -33,4 +33,3 @@ class ezrangeoptionSolrStorage extends ezdatatypeSolrStorage
     }
 }
 
-?>

--- a/classes/solrstorage/ezselectionsolrstorage.php
+++ b/classes/solrstorage/ezselectionsolrstorage.php
@@ -37,4 +37,3 @@ class ezselectionSolrStorage extends ezdatatypeSolrStorage
     }
 }
 
-?>

--- a/classes/solrstorage/ezurlsolrstorage.php
+++ b/classes/solrstorage/ezurlsolrstorage.php
@@ -30,4 +30,3 @@ class ezurlSolrStorage extends ezdatatypeSolrStorage
     }
 }
 
-?>

--- a/classes/solrstorage/ezusersolrstorage.php
+++ b/classes/solrstorage/ezusersolrstorage.php
@@ -31,4 +31,3 @@ class ezuserSolrStorage extends ezdatatypeSolrStorage
     }
 }
 
-?>

--- a/classes/solrstorage/ezxmltextsolrstorage.php
+++ b/classes/solrstorage/ezxmltextsolrstorage.php
@@ -42,4 +42,3 @@ class ezxmltextSolrStorage extends ezdatatypeSolrStorage
 }
 
 
-?>

--- a/modules/ezfind/elevate.php
+++ b/modules/ezfind/elevate.php
@@ -219,4 +219,4 @@ $Result['path'] = array( array( 'url' => false,
                          array( 'url' => false,
                                 'text' => ezpI18n::tr( 'extension/ezfind', 'Elevation' ) ) );
 
-?>
+

--- a/modules/ezfind/elevation_detail.php
+++ b/modules/ezfind/elevation_detail.php
@@ -116,4 +116,4 @@ if ( $object instanceof eZContentObject )
 }
 
 $Result['left_menu'] = "design:ezfind/backoffice_left_menu.tpl";
-?>
+

--- a/modules/ezfind/function_definition.php
+++ b/modules/ezfind/function_definition.php
@@ -228,4 +228,4 @@ $FunctionList['elevateConfiguration'] = array(   'name' => 'elevateConfiguration
                                                                                'type' => 'string',
                                                                                'required' => false,
                                                                                'default' => null ) ) );
-?>
+

--- a/modules/ezfind/module.php
+++ b/modules/ezfind/module.php
@@ -53,4 +53,4 @@ $ViewList[ 'query' ] = array(
 $FunctionList = array();
 $FunctionList['elevate'] = array();
 $FunctionList['query_admin'] = array();
-?>
+

--- a/modules/ezfind/remove_elevation.php
+++ b/modules/ezfind/remove_elevation.php
@@ -88,4 +88,4 @@ $Result['path'] = array( array( 'url' => false,
                                 'text' => ezpI18n::tr( 'extension/ezfind', 'eZFind' ) ),
                          array( 'url' => false,
                                 'text' => ezpI18n::tr( 'extension/ezfind', 'Remove Elevation' ) ) );
-?>
+


### PR DESCRIPTION
That's more a cosmetic pull request. And it avoids the 'Deprecated warnings' due to the old constructor style.
