### PR TITLE
Allowing fetch function to control highlighting, highlighting disabled by default

### DIFF
--- a/classes/ezfezpsolrquerybuilder.php
+++ b/classes/ezfezpsolrquerybuilder.php
@@ -140,10 +140,22 @@ class ezfeZPSolrQueryBuilder
         $enableElevation = isset( $params['EnableElevation'] )  ?  $params['EnableElevation'] : true;
         $distributedSearch = isset( $params['DistributedSearch'] ) ? $params['DistributedSearch'] : false;
         $fieldsToReturn = isset( $params['FieldsToReturn'] ) ? $params['FieldsToReturn'] : array();
-        $highlightParams = isset( $params['HighLightParams'] ) ? $params['HighLightParams'] : array();
         $searchResultClusterParams = isset( $params['SearchResultClustering'] ) ? $params['SearchResultClustering'] : array();
         $extendedAttributeFilter = isset( $params['ExtendedAttributeFilter'] ) ? $params['ExtendedAttributeFilter'] : array();
 
+        // Handling highlighting parameters
+        $highlightParams = array(
+            'hl' => $eZFindIni->variable( 'HighLighting', 'Enabled' ),
+            'hl.snippets' => $eZFindIni->variable( 'HighLighting', 'SnippetsPerField' ),
+            'hl.fragsize' => $eZFindIni->variable( 'HighLighting', 'FragmentSize' ),
+            'hl.requireFieldMatch' => $eZFindIni->variable( 'HighLighting', 'RequireFieldMatch' ),
+            'hl.simple.pre' => $eZFindIni->variable( 'HighLighting', 'SimplePre' ),
+            'hl.simple.post' => $eZFindIni->variable( 'HighLighting', 'SimplePost' ),
+        );
+        if( isset( $params[ 'HighLightParams' ] ) && !empty( $params[ 'HighLightParams' ] ) )
+        {
+            $highlightParams = array_merge( $highlightParams, $params[ 'HighLightParams' ] );
+        }
 
         // distributed search option
         // @since ezfind 2.2
@@ -304,7 +316,7 @@ class ezfeZPSolrQueryBuilder
         //the array_unique below is necessary because attribute identifiers are not unique .. and we get as
         //much highlight snippets as there are duplicate attribute identifiers
         //these are also in the list of query fields (dismax, ezpublish) request handlers
-	$queryFields = array_unique( $this->getClassAttributes( $contentClassID, $contentClassAttributeID, $fieldTypeExcludeList ) );
+        $queryFields = array_unique( $this->getClassAttributes( $contentClassID, $contentClassAttributeID, $fieldTypeExcludeList ) );
 
         //highlighting only in the attributes, otherwise the object name is repeated in the highlight, which is already
         //partly true as it is mostly composed of one or more attributes.
@@ -471,22 +483,16 @@ class ezfeZPSolrQueryBuilder
                 'version' => '2.2',
                 'fl' => $fieldsToReturnString,
                 'fq' => $filterQuery,
-                'hl' => $eZFindIni->variable( 'HighLighting', 'Enabled' ),
                 'hl.fl' => implode( ' ', $highLightFields ),
-                'hl.snippets' => $eZFindIni->variable( 'HighLighting', 'SnippetsPerField' ),
-                'hl.fragsize' => $eZFindIni->variable( 'HighLighting', 'FragmentSize' ),
-                'hl.requireFieldMatch' => $eZFindIni->variable( 'HighLighting', 'RequireFieldMatch' ),
-                'hl.simple.pre' => $eZFindIni->variable( 'HighLighting', 'SimplePre' ),
-                'hl.simple.post' => $eZFindIni->variable( 'HighLighting', 'SimplePost' ),
                 'wt' => 'php'
             ),
+            $highlightParams,
             $facetQueryParamList,
             $spellCheckParamList,
             $boostFunctionsParamList,
             $elevateParamList,
             $searchResultClusterParamList
         );
-
 
         if( isset( $extendedAttributeFilter['id'] ) && isset( $extendedAttributeFilter['params'] ) )
         {

--- a/classes/ezfmodulefunctioncollection.php
+++ b/classes/ezfmodulefunctioncollection.php
@@ -66,23 +66,57 @@ class ezfModuleFunctionCollection
     /**
      * Search function
      *
-     * @param string Query string
-     * @param int Offset
-     * @param int Limit
-     * @param array Facet definition
-     * @param array Filter parameters
-     * @param array Sort by parameters
-     * @param mixed Content class ID or list of content class IDs
-     * @param array list of subtree limitation node IDs
-     * @param boolean $enableElevation Controls whether elevation should be enabled or not
-     * @param boolean $forceElevation Controls whether elevation is forced. Applies when the srt criteria is NOT the default one ( 'score desc' ).
+     * @param string $query Query string
+     * @param int $offset Offset
+     * @param int $limit Limit
+     * @param array $facets Facet definition
+     * @param array $filters Filter parameters
+     * @param array $sortBy Sort by parameters
+     * @param mixed $classID Content class ID or list of content class IDs
+     * @param null $sectionID
+     * @param array $subtreeArray List of subtree limitation node IDs
+     * @param null $ignoreVisibility
+     * @param null $limitation
+     * @param bool $asObjects
+     * @param null $spellCheck
+     * @param null $boostFunctions
+     * @param string $queryHandler
+     * @param bool $enableElevation Controls whether elevation should be enabled or not
+     * @param bool $forceElevation Controls whether elevation is forced. Applies when the srt criteria is NOT the default one ( 'score desc' ).
+     * @param null $publishDate
+     * @param null $distributedSearch
+     * @param null $fieldsToReturn
+     * @param null $searchResultClustering
+     * @param array $extendedAttributeFilter
+     * @param bool $highlighted Controls whether highlighting is enabled or not
      *
      * @return array Search result
      */
-    public function search( $query, $offset = 0, $limit = 10, $facets = null,
-                            $filters = null, $sortBy = null, $classID = null, $sectionID = null,
-                            $subtreeArray = null, $ignoreVisibility = null, $limitation = null, $asObjects = true, $spellCheck = null, $boostFunctions = null, $queryHandler = 'ezpublish',
-                            $enableElevation = true, $forceElevation = false, $publishDate = null, $distributedSearch = null, $fieldsToReturn = null, $searchResultClustering = null, $extendedAttributeFilter = array() )
+    public function search(
+        $query,
+        $offset = 0,
+        $limit = 10,
+        $facets = null,
+        $filters = null,
+        $sortBy = null,
+        $classID = null,
+        $sectionID = null,
+        $subtreeArray = null,
+        $ignoreVisibility = null,
+        $limitation = null,
+        $asObjects = true,
+        $spellCheck = null,
+        $boostFunctions = null,
+        $queryHandler = 'ezpublish',
+        $enableElevation = true,
+        $forceElevation = false,
+        $publishDate = null,
+        $distributedSearch = null,
+        $fieldsToReturn = null,
+        $searchResultClustering = null,
+        $extendedAttributeFilter = array(),
+        $highlighted = false
+    )
     {
         $solrSearch = new eZSolr();
         $params = array( 'SearchOffset' => $offset,
@@ -105,7 +139,12 @@ class ezfModuleFunctionCollection
                          'DistributedSearch' => $distributedSearch,
                          'FieldsToReturn' => $fieldsToReturn,
                          'SearchResultClustering' => $searchResultClustering,
-                         'ExtendedAttributeFilter' => $extendedAttributeFilter );
+                         'ExtendedAttributeFilter' => $extendedAttributeFilter,
+                         'HighLightParams' => array(
+                             'hl' => $highlighted ? 'true': 'false'
+                         ),
+        );
+
         return array( 'result' => $solrSearch->search( $query, $params ) );
     }
 

--- a/design/ezdemo/templates/content/search.tpl
+++ b/design/ezdemo/templates/content/search.tpl
@@ -42,7 +42,9 @@
                               'filter', $filterParameters,
                               'publish_date', $dateFilter,
                               'spell_check', array( true() ),
-                              'search_result_clustering', hash( 'clustering', false() ) )
+                              'search_result_clustering', hash( 'clustering', false() ),
+                              'highlighted', true()
+                        )
                              )}
     {set $search_result=$search['SearchResult']}
     {set $search_count=$search['SearchCount']}

--- a/modules/ezfind/function_definition.php
+++ b/modules/ezfind/function_definition.php
@@ -100,7 +100,13 @@ $FunctionList['search'] = array( 'name' => 'search',
                                                         array ( 'name'  => 'extended_attribute_filter',
                                                                 'type' => 'array',
                                                                 'required' => false,
-                                                                'default' => array() )) );
+                                                                'default' => array() ),
+                                                        array ( 'name'  => 'highlighted',
+                                                                'type' => 'boolean',
+                                                                'required' => false,
+                                                                'default' => false ),
+                                 )
+);
 
 
 $FunctionList['getDefaultSearchFacets'] = array( 'name' => 'getDefaultSearchFacets',

--- a/settings/ezfind.ini
+++ b/settings/ezfind.ini
@@ -290,7 +290,7 @@ BoostTerms=true
 # true or false to enable or disable the highlighting
 # will be passed in hl parameter of the query Solr
 # http://wiki.apache.org/solr/HighlightingParameters#hl
-Enabled=true
+Enabled=false
 # highlight only matched fields or not
 # will be passed in hl.requireFieldMatch of the Solr query
 # http://wiki.apache.org/solr/HighlightingParameters#hl.requireFieldMatch


### PR DESCRIPTION
We recognized a significant performance gain if query highlighting is disabled. We think in most cases the highlighting is not required and disable it by default in this pull request.
That pull request also allows you to specify in the fetch function wether you'd like to have or not have the highlighting enabled.

There is a related pull request here which would make the code cleaner:
https://github.com/ezsystems/ezfind/pull/214