### PR TITLE
New template operators

### DIFF
--- a/autoloads/eztemplateautoload.php
+++ b/autoloads/eztemplateautoload.php
@@ -11,5 +11,11 @@ $eZTemplateOperatorArray = array();
 
 $eZTemplateOperatorArray[] = array(
     'class' => 'ezfTemplateOperators',
-    'operator_names' => array( 'solr_escape', 'solr_quotes_escape' )
+    'operator_names' => array(
+		'solr_escape',
+		'solr_quotes_escape',
+		'solr_realescape',
+		'solr_date',
+		'solr_local_time',
+	)
 );

--- a/classes/ezfTemplateOperators.php
+++ b/classes/ezfTemplateOperators.php
@@ -98,6 +98,14 @@ class ezfTemplateOperators
         return ezfSolrDocumentFieldBase::convertTimestampToDate( $string );
     }
 
+	/**
+	 * Internally solr uses UTC dates. If you need that date in context of
+	 * eZ Publish, you need to translate it to the configured timezone. This
+	 * function is helping you with that.
+	 *
+	 * @param $string UTC date from solr
+	 * @return bool|int
+	 */
     public function solrLocalTime( $string )
     {
         $return = false;
@@ -111,7 +119,7 @@ class ezfTemplateOperators
         if( $utc_date )
         {
             $local_date = $utc_date;
-            $local_date->setTimeZone(new DateTimeZone( 'America/New_York' ) );
+            $local_date->setTimeZone( new DateTimeZone( date_default_timezone_get() ) );
 
             $return = $local_date->getTimestamp();
         }


### PR DESCRIPTION
Template operators for
1) escaping a string used in solr query
There is already the operator 'solr_escape' but it's pretty much useless - it will break for a few special characters. For example:
'meta_main_path_string_ms:', $node.path_string|solr_escape()

Make sure you use the new operator solr_realescape instead.

2) date format specific for solr
Parses a unix timestamp to a date format solr can work with

3) time format specific for solr
Solr stores UTC times internally. That operator helps you to get the timezone specific timestamp
