### PR TITLE
Adding the SOLR doc to result objects - support more attributes for non-local SOLR result objects

### DIFF
--- a/classes/ezfindresultnode.php
+++ b/classes/ezfindresultnode.php
@@ -27,7 +27,6 @@ class eZFindResultNode extends eZContentObjectTreeNode
             'highlight',
             'score_percent',
             'elevated',
-            'global_id',
             'doc',
         );
     }

--- a/classes/ezfindresultobject.php
+++ b/classes/ezfindresultobject.php
@@ -13,7 +13,7 @@ class eZFindResultObject extends eZContentObject
     function __construct( $rows = array() )
     {
         $this->LocalAttributeValueList = array();
-		$this->LocalAttributeNameList = array( 'doc' );
+        $this->LocalAttributeNameList = array( 'doc' );
 
         foreach ( $rows as $name => $value )
         {

--- a/classes/ezfindresultobject.php
+++ b/classes/ezfindresultobject.php
@@ -13,7 +13,7 @@ class eZFindResultObject extends eZContentObject
     function __construct( $rows = array() )
     {
         $this->LocalAttributeValueList = array();
-        $this->LocalAttributeNameList = array( 'published' );
+		$this->LocalAttributeNameList = array( 'doc' );
 
         foreach ( $rows as $name => $value )
         {
@@ -26,8 +26,35 @@ class eZFindResultObject extends eZContentObject
     */
     function attribute( $attr, $noFunction = false )
     {
-        return isset( $this->LocalAttributeValueList[$attr] ) ?
-                $this->LocalAttributeValueList[$attr] : null;
+        $returnVal = null;
+
+        if( isset( $this->LocalAttributeValueList[ $attr ] ) )
+        {
+            $returnVal = $this->LocalAttributeValueList[ $attr ];
+        }
+        else
+        {
+            switch( $attr )
+            {
+                case 'published':
+                {
+                    $returnVal = strtotime( $this->LocalAttributeValueList[ 'doc' ][ eZSolr::getMetaFieldName( 'published' ) ] );
+                } break;
+
+                case 'state_id_array':
+                {
+                    $returnVal = $this->LocalAttributeValueList[ 'doc' ][ eZSolr::getMetaFieldName( 'object_states' ) ];
+                } break;
+
+                case 'contentclass_id':
+                case 'class_identifier':
+                {
+                    $returnVal = $this->LocalAttributeValueList[ 'doc' ][ eZSolr::getMetaFieldName( $attr ) ];
+                } break;
+            }
+        }
+
+        return $returnVal;
     }
 
     /*!

--- a/search/plugins/ezsolr/ezsolr.php
+++ b/search/plugins/ezsolr/ezsolr.php
@@ -1767,6 +1767,7 @@ class eZSolr implements ezpSearchEngine
                 }
 
                 $resultTree->setAttribute( 'name', $doc[ezfSolrDocumentFieldBase::generateMetaFieldName( 'name' )] );
+                $resultTree->setAttribute( 'doc', $doc );
                 $resultTree->setAttribute( 'published', $doc[ezfSolrDocumentFieldBase::generateMetaFieldName( 'published' )] );
                 $resultTree->setAttribute( 'global_url_alias', $globalURL );
                 $resultTree->setAttribute( 'highlight', isset( $highLights[$doc[ezfSolrDocumentFieldBase::generateMetaFieldName( 'guid' )]] ) ?


### PR DESCRIPTION
**Background**
A search with ezfind will return an array of result objects. Those objects are of the type 'eZFindResultNode'. That class extends the 'eZContentObjectTreeNode' class. In the template context you can it basically does the same thing like {$node.class_identifier}. For a search that contains non-local result object (so index content from another eZ Publish instance), you cannot access all attributes like {$node.state_id_array}. That's because ezfind is checking the DB for those values and for a non-local result object it is not possible to check the DB.

**The changes**
This patch extends the 'eZFindResultNode' class and add an attribute _doc_. It is the SOLR document for the eZ Publish node. It contains most of the attributes. Now with the SOLR document available it is now possible to return correct values for attributes like {$node.state_id_array} in case of non-local result objects.

**Testing instructions**

I assume it's too complicated to setup a SOLR index with non-local entries. But you can test that the new attribute _doc_ is available:

```
{def
    $result = fetch( 'ezfind', 'search', hash(
        'filter', 'meta_main_node_id_si:2'
}

{$result.SearchResult.0.doc|dump()}
```

**Concerns**
The size of a SOLR document is a few KB. So large result sets are getting quite big and the memory usage is increased. We can improve that in future patches.