### PR TITLE
Fixing wrong 'continue' usage

### DIFF
--- a/classes/ezfezpsolrquerybuilder.php
+++ b/classes/ezfezpsolrquerybuilder.php
@@ -941,7 +941,7 @@ class ezfeZPSolrQueryBuilder
                             eZDebug::writeNotice( 'Sort field does not exist in local installation, but may still be valid: ' .
                                                   $baseFieldName,
                                                   __METHOD__ );
-                            continue;
+                            continue 2;
                         }
                     } break;
                 }
@@ -1167,7 +1167,7 @@ class ezfeZPSolrQueryBuilder
                             eZDebug::writeNotice( 'Facet field does not exist in local installation, but may still be valid: ' .
                                                   $facetDefinition['field'],
                                                   __METHOD__ );
-                            continue;
+                            continue 2;
                         }
                         $queryPart['field'] = $fieldName;
                     } break;
@@ -1687,7 +1687,7 @@ class ezfeZPSolrQueryBuilder
                         else
                         {
                             eZDebug::writeDebug( $limitationType, __METHOD__ . ' unknown limitation type: ' . $limitationType );
-                            continue;
+                            continue 2;
                         }
                     }
                 }


### PR DESCRIPTION
In switch statements, 'continue' is handled like 'break'. The correct logic did require a 'continue 2'