### PR TITLE
Adding more fields to non local solr documents

### DIFF
--- a/classes/ezfezpsolrquerybuilder.php
+++ b/classes/ezfezpsolrquerybuilder.php
@@ -445,15 +445,33 @@ class ezfeZPSolrQueryBuilder
         // Document transformer fields since eZ Find 5.4
         $docTransformerFields = array( '[elevated]' );
 
-        $fieldsToReturnString = eZSolr::getMetaFieldName( 'guid' ) . ' ' . eZSolr::getMetaFieldName( 'installation_id' ) . ' ' .
-                eZSolr::getMetaFieldName( 'main_url_alias' ) . ' ' . eZSolr::getMetaFieldName( 'installation_url' ) . ' ' .
-                eZSolr::getMetaFieldName( 'id' ) . ' ' . eZSolr::getMetaFieldName( 'main_node_id' ) . ' ' .
-                eZSolr::getMetaFieldName( 'language_code' ) . ' ' . eZSolr::getMetaFieldName( 'name' ) .
-                ' score ' . eZSolr::getMetaFieldName( 'published' ) . ' ' . eZSolr::getMetaFieldName( 'path_string' ) . ' ' .
-                eZSolr::getMetaFieldName( 'main_path_string' ) . ' ' . eZSolr::getMetaFieldName( 'is_invisible' ) . ' ' .
-                implode( ' ', $docTransformerFields) . ' ' .
-                implode( ' ', $extraFieldsToReturn );
+        $defaultFields = [
+            'guid',
+            'installation_id',
+            'main_url_alias',
+            'installation_url',
+            'id',
+            'remote_id',
+            'main_node_id',
+            'language_code',
+            'name',
+            'published',
+            'modified',
+            'path_string',
+            'main_path_string',
+            'is_invisible',
+            'class_name',
+            'class_identifier',
+        ];
 
+        array_walk( $defaultFields, function(&$v){ $v = eZSolr::getMetaFieldName( $v ); } );
+
+        $fieldsToReturnString =
+            implode(' ', $defaultFields ) .
+            ' score ' .
+            implode( ' ', $docTransformerFields) . ' ' .
+            implode( ' ', $extraFieldsToReturn );
+        
         if ( ! $asObjects )
         {
             if ( empty( $fieldsToReturn ))

--- a/classes/ezfindresultobject.php
+++ b/classes/ezfindresultobject.php
@@ -13,7 +13,10 @@ class eZFindResultObject extends eZContentObject
     function __construct( $rows = array() )
     {
         $this->LocalAttributeValueList = array();
-        $this->LocalAttributeNameList = array( 'doc' );
+        $this->LocalAttributeNameList = array(
+            'doc',
+            'is_local_installation'
+        );
 
         foreach ( $rows as $name => $value )
         {
@@ -34,23 +37,43 @@ class eZFindResultObject extends eZContentObject
         }
         else
         {
-            switch( $attr )
+            if ( $this->attribute( 'is_local_installation' ) )
             {
-                case 'published':
+                $returnVal = eZContentObjectTreeNode::attribute( $attr, $noFunction );
+            }
+            else
+            {
+                switch( $attr )
                 {
-                    $returnVal = strtotime( $this->LocalAttributeValueList[ 'doc' ][ eZSolr::getMetaFieldName( 'published' ) ] );
-                } break;
+                    case 'published':
+                    {
+                        $returnVal = strtotime( $this->LocalAttributeValueList[ 'doc' ][ eZSolr::getMetaFieldName( 'published' ) ] );
+                    }
+                    break;
 
-                case 'state_id_array':
-                {
-                    $returnVal = $this->LocalAttributeValueList[ 'doc' ][ eZSolr::getMetaFieldName( 'object_states' ) ];
-                } break;
+                    case 'modified':
+                    {
+                        $returnVal = strtotime( $this->LocalAttributeValueList[ 'doc' ][ eZSolr::getMetaFieldName( 'modified' ) ] );
+                    }
+                    break;
 
-                case 'contentclass_id':
-                case 'class_identifier':
-                {
-                    $returnVal = $this->LocalAttributeValueList[ 'doc' ][ eZSolr::getMetaFieldName( $attr ) ];
-                } break;
+                    case 'state_id_array':
+                    {
+                        $returnVal = $this->LocalAttributeValueList[ 'doc' ][ eZSolr::getMetaFieldName( 'object_states' ) ];
+                    }
+                    break;
+
+                    case 'contentclass_id':
+                    case 'class_identifier':
+                    case 'class_name':
+                    case 'main_node_id':
+                    case 'id':
+                    case 'remote_id':
+                    {
+                        $returnVal = $this->LocalAttributeValueList[ 'doc' ][ eZSolr::getMetaFieldName( $attr ) ];
+                    }
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
**Changes in classes/ezfezpsolrquerybuilder.php**

Refactor the code to build $fieldsToReturnString -> more readable.
It is adding 2 fields to the default fields: 'class_name', 'class_identifier'

**Changes in classes/ezfindresultnode.php**

* Adding 'installation_id' as an attribute
* Using a 'switch' statement when returning "local variables" -> more readable.
* Forwarding the info about 'is_local_installation' to instances of eZFindResultObject

**Changes in classes/ezfindresultobject.php**

* add 'is_local_installation' as a local variable
* rely on eZContentObjectTreeNode attribute values in case of 'is_local_installation' -> no out of sync issues.
* returning more attribute values in case of non-local solr documents

**New properties you can fetch**
If it's a non-local solr document, you can still fetch following new properties/attributes

*eZFindResultNode*
* installation_id

*eZFindResultObject*
* is_local_installation
* modified
* class_name
* main_node_id
* id
* remote_id