### PR TITLE
Introducing Configuration transporter

### DIFF
--- a/classes/configurationtransporters/ezfconfigurationtransportersolr.php
+++ b/classes/configurationtransporters/ezfconfigurationtransportersolr.php
@@ -9,7 +9,6 @@ class eZFConfigurationTransporterSolr extends eZFConfigurationTransporter
          * multiple language indexes, or the default one
          *
          * @TODO: handle exceptions properly
-         * @TODO: move eZFindElevateConfiguration::synchronizeWithSolr to eZFConfigurationTransporterSolr
          */
         $solr = new eZSolr();
 
@@ -17,13 +16,74 @@ class eZFConfigurationTransporterSolr extends eZFConfigurationTransporter
         {
             foreach ( $solr->SolrLanguageShards as $shard )
             {
-                eZFindElevateConfiguration::synchronizeWithSolr( $shard );
+                $this->synchronizeWithSolr( $shard, $configuration );
             }
             return true;
         }
         else
         {
-            return eZFindElevateConfiguration::synchronizeWithSolr( $solr );
+            return $this->synchronizeWithSolr( new eZSolrBase(), $configuration );
         }
     }
+
+    /**
+     * Synchronizes the elevate configuration stored in the DB
+     * with the one actually used by Solr.
+     */
+    protected function synchronizeWithSolr( $shard, $configuration )
+    {
+        if( $configuration )
+        {
+            try
+            {
+                $this->pushConfigurationToSolr( $shard, $configuration );
+            }
+            catch ( Exception $e )
+            {
+                eZFindElevateConfiguration::$lastSynchronizationError = $e->getMessage();
+                eZDebug::writeError( eZFindElevateConfiguration::$lastSynchronizationError, __METHOD__ );
+                return false;
+            }
+        }
+        else
+        {
+            $message = ezpI18n::tr( 'extension/ezfind/elevate', "Error while generating the configuration XML" );
+            eZFindElevateConfiguration::$lastSynchronizationError = $message;
+            eZDebug::writeError( $message, __METHOD__ );
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Pushes the configuration XML to Solr through a custom requestHandler ( HTTP/ReST ).
+     * The requestHandler ( Solr extension ) will take care of reloading the configuration.
+     */
+    protected function pushConfigurationToSolr( $shard, $configuration )
+    {
+        $params = array(
+            'qt' => 'ezfind',
+            eZFindElevateConfiguration::CONF_PARAM_NAME => $configuration
+        );
+
+
+        $result = $shard->pushElevateConfiguration( $params );
+
+        if ( ! $result )
+        {
+            $message = ezpI18n::tr( 'extension/ezfind/elevate', 'An unknown error occured in updating Solr\'s elevate configuration.' );
+            eZDebug::writeError( $message, __METHOD__ );
+            throw new Exception( $message );
+        }
+        elseif ( isset( $result['error'] ) )
+        {
+            eZDebug::writeError( $result['error'], __METHOD__ );
+        }
+        else
+        {
+            eZDebug::writeNotice( "Successful update of Solr's configuration.", __METHOD__ );
+        }
+    }
+
 }

--- a/classes/configurationtransporters/ezfconfigurationtransportersolr.php
+++ b/classes/configurationtransporters/ezfconfigurationtransportersolr.php
@@ -1,0 +1,29 @@
+<?php
+
+class eZFConfigurationTransporterSolr extends eZFConfigurationTransporter
+{
+    public function push( $configuration )
+    {
+        /**
+         * synchronises elevate configuration across language shards in case of
+         * multiple language indexes, or the default one
+         *
+         * @TODO: handle exceptions properly
+         * @TODO: move eZFindElevateConfiguration::synchronizeWithSolr to eZFConfigurationTransporterSolr
+         */
+        $solr = new eZSolr();
+
+        if( $solr->UseMultiLanguageCores )
+        {
+            foreach ( $solr->SolrLanguageShards as $shard )
+            {
+                eZFindElevateConfiguration::synchronizeWithSolr( $shard );
+            }
+            return true;
+        }
+        else
+        {
+            return eZFindElevateConfiguration::synchronizeWithSolr( $solr );
+        }
+    }
+}

--- a/classes/configurationtransporters/ezfconfigurationtransporterzookeepercli.php
+++ b/classes/configurationtransporters/ezfconfigurationtransporterzookeepercli.php
@@ -3,16 +3,19 @@
 class eZFConfigurationTransporterZookeeperCli extends ezfConfigurationTransporter
 {
     protected $cli;
+    protected $configFilePath;
 
     public function __construct( $parameters )
     {
         $this->cli = $parameters[ 'cli' ] ?? '/opt/zookeeper/bin/zkCli.sh';
+        $this->configFilePath = $parameters[ 'ConfigFilePath' ] ?? '/configs/ezp_collection_config/elevate.xml';
+
         parent::__construct( $parameters );
     }
 
     public function push( $configuration )
     {
-        exec($this->cli . ' set /configs/ezp_collection_config/elevate.xml ' . escapeshellarg( $configuration ), $output, $exitCode );
+        exec($this->cli . ' set '. $this->configFilePath . ' ' . escapeshellarg( $configuration ), $output, $exitCode );
 
         return $exitCode === 0;
     }

--- a/classes/configurationtransporters/ezfconfigurationtransporterzookeepercli.php
+++ b/classes/configurationtransporters/ezfconfigurationtransporterzookeepercli.php
@@ -1,0 +1,17 @@
+<?php
+
+class eZFConfigurationTransporterZookeeperCli extends ezfConfigurationTransporter
+{
+    protected $cli;
+
+    public function __construct( $parameters )
+    {
+        $this->cli = $parameters[ 'cli' ] ?? '/opt/zookeeper/bin/zkCli.sh';
+        parent::__construct( $parameters );
+    }
+
+    public function push( $configuration )
+    {
+        exec($this->cli . ' set /configs/ezp_collection_config/elevate.xml ' . escapeshellarg( $configuration ) );
+    }
+}

--- a/classes/configurationtransporters/ezfconfigurationtransporterzookeepercli.php
+++ b/classes/configurationtransporters/ezfconfigurationtransporterzookeepercli.php
@@ -13,10 +13,20 @@ class eZFConfigurationTransporterZookeeperCli extends ezfConfigurationTransporte
         parent::__construct( $parameters );
     }
 
-    public function push( $configuration )
+	/**
+	 * @param string $elevateXmlString
+	 * @return bool
+	 */
+    public function push( $elevateXmlString )
     {
-        exec($this->cli . ' set '. $this->configFilePath . ' ' . escapeshellarg( $configuration ), $output, $exitCode );
+        exec($this->cli . ' set '. $this->configFilePath . ' \'' . $elevateXmlString . '\'', $output, $exitCode );
 
-        return $exitCode === 0;
+        if( $exitCode === 0 )
+        {
+            $solrBase = new eZSolrBase();
+            return $solrBase->reloadCollection();
+        }
+
+        return false;
     }
 }

--- a/classes/configurationtransporters/ezfconfigurationtransporterzookeepercli.php
+++ b/classes/configurationtransporters/ezfconfigurationtransporterzookeepercli.php
@@ -12,6 +12,8 @@ class eZFConfigurationTransporterZookeeperCli extends ezfConfigurationTransporte
 
     public function push( $configuration )
     {
-        exec($this->cli . ' set /configs/ezp_collection_config/elevate.xml ' . escapeshellarg( $configuration ) );
+        exec($this->cli . ' set /configs/ezp_collection_config/elevate.xml ' . escapeshellarg( $configuration ), $output, $exitCode );
+
+        return $exitCode === 0;
     }
 }

--- a/classes/ezfconfigurationtransporter.php
+++ b/classes/ezfconfigurationtransporter.php
@@ -1,0 +1,33 @@
+<?php
+
+class eZFConfigurationTransporter
+{
+    protected $parameters;
+
+    public function __construct( $parameters )
+    {
+        $this->parameters = $parameters;
+    }
+
+    public function push( $configuration )
+    {
+        eZFindElevateConfiguration::$lastSynchronizationError = 'ConfigurationTransporter class does not exits.';
+        return false;
+    }
+
+    public static function factory()
+    {
+        $settings = eZINI::instance( 'solr.ini' );
+        $class = $settings->variable( 'SolrBase', 'ConfigurationTransporter' );
+        $parameters = $settings->variable( 'SolrBase', 'ConfigurationTransporterParameters' );
+
+        if( class_exists( $class ) )
+        {
+            return new $class( $parameters );
+        }
+        else
+        {
+            return new self( $parameters );
+        }
+    }
+}

--- a/classes/ezfindelevateconfiguration.php
+++ b/classes/ezfindelevateconfiguration.php
@@ -317,37 +317,6 @@ class eZFindElevateConfiguration extends eZPersistentObject
     }
 
     /**
-     * Synchronizes the elevate configuration stored in the DB
-     * with the one actually used by Solr.
-     *
-     * @return boolean true if the whole operation passed, false otherwise.
-     */
-    public static function synchronizeWithSolr( $shard = null )
-    {
-        if ( self::generateConfiguration() )
-        {
-            try
-            {
-                self::pushConfigurationToSolr( $shard );
-            }
-            catch ( Exception $e )
-            {
-                self::$lastSynchronizationError = $e->getMessage();
-                eZDebug::writeError( self::$lastSynchronizationError, __METHOD__ );
-                return false;
-            }
-        }
-        else
-        {
-            $message = ezpI18n::tr( 'extension/ezfind/elevate', "Error while generating the configuration XML" );
-            self::$lastSynchronizationError = $message;
-            eZDebug::writeError( $message, __METHOD__ );
-            return false;
-        }
-        return true;
-    }
-
-    /**
      * @return string
      */
     public static function getElevateConfiguration()
@@ -440,44 +409,6 @@ class eZFindElevateConfiguration extends eZPersistentObject
     }
 
     /**
-     * Pushes the configuration XML to Solr through a custom requestHandler ( HTTP/ReST ).
-     * The requestHandler ( Solr extension ) will take care of reloading the configuration.
-     *
-     * @see $configurationXML
-     * @return void
-     */
-    protected static function pushConfigurationToSolr( $shard = null )
-    {
-        $params = array(
-            'qt' => 'ezfind',
-            self::CONF_PARAM_NAME => self::getConfiguration()
-        );
-
-        // Keep previous behaviour, but should not be needed
-        if ( $shard === null )
-        {
-            $shard = new eZSolrBase();
-        }
-
-        $result = $shard->pushElevateConfiguration( $params );
-
-        if ( ! $result )
-        {
-            $message = ezpI18n::tr( 'extension/ezfind/elevate', 'An unknown error occured in updating Solr\'s elevate configuration.' );
-            eZDebug::writeError( $message, __METHOD__ );
-            throw new Exception( $message );
-        }
-        elseif ( isset( $result['error'] ) )
-        {
-            eZDebug::writeError( $result['error'], __METHOD__ );
-        }
-        else
-        {
-            eZDebug::writeNotice( "Successful update of Solr's configuration.", __METHOD__ );
-        }
-    }
-
-    /**
      * Generates a well-formed array of elevate-related query parameters.
      *
      * @param boolean $forceElevation Whether elevation should be forced or not. Parameter supported at runtime from Solr@rev:735117
@@ -515,4 +446,4 @@ class eZFindElevateConfiguration extends eZPersistentObject
 }
 // Initialize the static property containing <eZINI> solr.ini
 eZFindElevateConfiguration::$solrINI = eZINI::instance( 'solr.ini' );
-?>
+

--- a/classes/ezsolrbase.php
+++ b/classes/ezsolrbase.php
@@ -415,6 +415,37 @@ class eZSolrBase
     }
 
     /**
+     * @return string
+     */
+    public function getCollectionName()
+    {
+        $parsedUrl = parse_url( $this->SearchServerURI );
+        if( isset( $parsedUrl[ 'path' ] ) )
+        {
+            $pathParts = explode( '/', $parsedUrl[ 'path' ] );
+            return $pathParts[ 2 ] ?? 'ezp-default';
+        }
+
+        return 'ezp-default';
+    }
+
+    /**
+     * @return bool
+     */
+    public function reloadCollection()
+    {
+        $collectionName = $this->getCollectionName();
+
+        if( $collectionName )
+        {
+            $response = $this->rawSolrRequest( '/admin/collections?action=RELOAD&name=' . $collectionName );
+            return $response[ 'responseHeader' ][ 'status' ] === 0;
+        }
+
+        return false;
+    }
+
+    /**
      * Proxy method to {@link self::sendHTTPRequest()}.
      * Sometimes, an overloaded Solr server can result a timeout and drop the connection
      * In this case, we will retry just after, with a max number of retries defined in solr.ini ([SolrBase].ProcessMaxRetries)

--- a/modules/ezfind/elevate.php
+++ b/modules/ezfind/elevate.php
@@ -189,9 +189,10 @@ else if ( $http->hasPostVariable( 'ezfind-searchelevateconfigurations-do' ) or
 // Synchronise Elevate configuration with Solr :
 else if ( $http->hasPostVariable( 'ezfind-elevate-synchronise' ) )
 {
-    $solr = new eZSolr();
-    //if ( eZFindElevateConfiguration::synchronizeWithSolr() )
-    if ( $solr->pushElevateConfiguration() )
+    $configurationTransporter = eZFConfigurationTransporter::factory();
+    $success = $configurationTransporter->push( eZFindElevateConfiguration::getElevateConfiguration() );
+
+    if ( $success )
     {
         $feedback['synchronisation_ok'] = true;
     }

--- a/search/plugins/ezsolr/ezsolr.php
+++ b/search/plugins/ezsolr/ezsolr.php
@@ -1596,29 +1596,6 @@ class eZSolr implements ezpSearchEngine
 
     }
 
-
-    /**
-     * synchronises elevate configuration across language shards in case of
-     * multiple lnguage indexes, or the default one
-     *
-     * @TODO: handle exceptions properly
-     */
-    public function pushElevateConfiguration()
-    {
-        if ( $this->UseMultiLanguageCores == true )
-        {
-            foreach ( $this->SolrLanguageShards as $shard )
-            {
-                eZFindElevateConfiguration::synchronizeWithSolr( $shard );
-            }
-            return true;
-        }
-        else
-        {
-            return eZFindElevateConfiguration::synchronizeWithSolr( $this->Solr );
-        }
-    }
-
     /**
      * Translates a solr response into result objects or a slightly modified array.
      * The $asObjects parameter controls which of the 2 return formats get send back.

--- a/search/plugins/ezsolr/ezsolr.php
+++ b/search/plugins/ezsolr/ezsolr.php
@@ -900,7 +900,7 @@ class eZSolr implements ezpSearchEngine
 
         // 1: remove the assciated "elevate" configuration
         eZFindElevateConfiguration::purge( '', $contentObjectId );
-        //eZFindElevateConfiguration::synchronizeWithSolr();
+
         $this->pushElevateConfiguration();
 
         // @todo Remove if accepted. Optimize is bad on runtime.

--- a/search/plugins/ezsolr/ezsolr.php
+++ b/search/plugins/ezsolr/ezsolr.php
@@ -898,10 +898,21 @@ class eZSolr implements ezpSearchEngine
             $commit = true;
         }
 
-        // 1: remove the assciated "elevate" configuration
-        eZFindElevateConfiguration::purge( '', $contentObjectId );
+        // 1: remove the associated "elevate" configuration
+        if( eZFindElevateConfiguration::fetchConfigurationForObject(
+            $contentObjectId,
+            true,
+            null,
+            null,
+            true
+        )
+        )
+        {
+            eZFindElevateConfiguration::purge( '', $contentObjectId );
 
-        $this->pushElevateConfiguration();
+            $configurationTransporter = eZFConfigurationTransporter::factory();
+            $configurationTransporter->push( eZFindElevateConfiguration::getElevateConfiguration() );
+        }
 
         // @todo Remove if accepted. Optimize is bad on runtime.
         $optimize = false;

--- a/settings/solr.ini
+++ b/settings/solr.ini
@@ -53,3 +53,4 @@ ConfigurationTransporter=eZFConfigurationTransporterSolr
 # Parameters are send to ConfigurationTransporter constructor
 #ConfigurationTransporterParameters[]
 #ConfigurationTransporterParameters[cli]=/opt/zookeeper/bin/zkCli.sh
+#ConfigurationTransporterParameters[ConfigFilePath]=/configs/ezp_collection_config/elevate.xml

--- a/settings/solr.ini
+++ b/settings/solr.ini
@@ -45,3 +45,11 @@ Shards[]
 #Shards[nor-NO]=http://localhost:8983/solr/nor-NO
 #Shards[myforeignindex]=http://myotherhost:8983/solr
 
+# valid options:
+# eZFConfigurationTransporterSolr
+# eZFConfigurationTransporterZookeeperCli
+ConfigurationTransporter=eZFConfigurationTransporterSolr
+
+# Parameters are send to ConfigurationTransporter constructor
+#ConfigurationTransporterParameters[]
+#ConfigurationTransporterParameters[cli]=/opt/zookeeper/bin/zkCli.sh


### PR DESCRIPTION
Currently, it's only possible to syncronize the elevate configuration with a solr instance directly. At a client installation, we do have a different setup: the solr configuration is managed by zookeeper - a system to have high availability for solr.

This pull request introduces "Configuration transporter" classes. There is one for "solr" executing the existing syncronization and a new one for zookeeper. There is a factory function to chose a transporter based on the settings.