### PR TITLE
Custom fields for the eztags extension

### DIFF
--- a/java/solr/ezp-default/conf/schema.xml
+++ b/java/solr/ezp-default/conf/schema.xml
@@ -692,6 +692,8 @@
         unknown fields indexed and/or stored by default -->
    <!--dynamicField name="*" type="ignored" multiValued="true" /-->
 
+   <field name="ezf_df_tags" type="lckeyword" indexed="true" stored="true" multiValued="true" termVectors="true"/>
+   <field name="ezf_df_tag_ids" type="sint" indexed="true" stored="true" multiValued="true" termVectors="true"/>
  </fields>
 
  <!-- Field to use to determine and enforce document uniqueness.


### PR DESCRIPTION
We could add the required fields for the eztags extension to the schema. Even if we have installations that don't use eztags, I believe those fields won't hurt so much.

Background: I did a composer update for CSM and it is overwriting the schema file. The default schema file is missing the fields for the eztags extension but we're using it for CSM. My idea is to just add those 2 fields.

What do you think?