### PR TITLE
Add new [SearchSettings] block to set the SortBy value [#620]

### DIFF
--- a/settings/ezfind.ini
+++ b/settings/ezfind.ini
@@ -265,6 +265,19 @@ FilterHiddenFromDB=disabled
 # Option to exclude owner name from being used as a query field in searches (default: disabled )
 ExcludeOwnerName=enabled
 
+[SearchSettings]
+# The sort_by parameter is used to define the sort order of the search result.
+# To see what are the supported options visit the following url:
+# https://ezpublishdoc.mugo.ca/Extensions/eZ-Publish-extensions/eZ-Find/eZ-Find-2.1/Customization/Template-fetch-functions#Sort_by
+# SortBy key   = sort option. Possible values: [visit link above]
+# SortBy value = sort order. Possible values: [asc|desc]
+# It is also possible to specify multiple sort options through this variable.
+SortBy[]
+SortBy[published]=desc
+#SortBy[score]=desc
+#SortBy[author]=desc
+#SortBy[path]=desc
+
 [MoreLikeThis]
 #Experimental!!
 #fields to use for query term extraction: proper fields "native",


### PR DESCRIPTION
Hi @pkamps ,

I completely forgot about this interesting PR so let's see if we can merge this one into our own forks. (Ibexa said no to this merge long time ago).

Basically this PR allows to set the 'sortBy' (sort order of the search result) reading the values from a new ini block.
https://ezpublishdoc.mugo.ca/Extensions/eZ-Publish-extensions/eZ-Find/eZ-Find-2.1/Customization/Template-fetch-functions#Sort_by

Right now the sortBy is hardcoded here:
[extension/ezjscore/classes/ezjscserverfunctionsjs.php](https://github.com/mugoweb/ezpublish-legacy/blob/master/extension/ezjscore/classes/ezjscserverfunctionsjs.php#L445)

The goal is to remove the hardcoded sort by logic and to be able to read either ini setting or post variable.

This PR is related to this one: 
https://github.com/mugoweb/ezpublish-legacy/pull/234

Thanks!

PS. This is the original ticket where this was implemented https://app.assembla.com/spaces/mugo-development-general/tickets/620